### PR TITLE
fix: Install wheel before other pip dependencies

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+* text=auto eol=lf
+*.{cmd,[cC][mM][dD]} text eol=crlf
+*.{bat,[bB][aA][tT]} text eol=crlf

--- a/detect-secrets/scripts/activate.sh
+++ b/detect-secrets/scripts/activate.sh
@@ -48,6 +48,7 @@ activate() {
 
 install() {
     echo 'Installing pre-commit framework...'
+    pip install wheel
     pip install pre-commit detect-secrets==1.0.3 pyahocorasick
 
     echo 'Installing pre-commit hooks from configuration...'


### PR DESCRIPTION
For systems that do not already have the `wheel` package installed, this ensure that wheel is available if needed by other packages such as `pyahocorasick` in our use case.